### PR TITLE
retry opening port instead of reporting failed ones

### DIFF
--- a/ooni/utils/simple_http.py
+++ b/ooni/utils/simple_http.py
@@ -3,7 +3,7 @@ from twisted.internet.error import CannotListenError
 from twisted.web import static, server
 from twisted.web.resource import Resource
 
-from sys import argv
+import sys
 
 DEFAULT_PORT = 8000
 
@@ -18,13 +18,14 @@ class Hello(Resource):
 
 listen_port = DEFAULT_PORT
 
-for i in range(0, len(argv)):
-    if  argv[i] == "--port":
-        listen_port = int(argv[i+1])
+for i in range(0, len(sys.argv)):
+    if  sys.argv[i] == "--port":
+        listen_port = int(sys.argv[i+1])
             
 site = server.Site(Hello())
 try:
     reactor.listenTCP(listen_port, site)
     reactor.run()
 except CannotListenError:
-    print "Someone else is already listening on " + str(listen_port)
+    sys.stderr.write("Someone else is already listening on " + str(listen_port))
+    sys.exit(2)


### PR DESCRIPTION
This avoids reporting when the HTTP server failed to start or bind.