### PR TITLE
report local IP address, retrieve address and build URL

### DIFF
--- a/ooni/nettests/experimental/peer_http_reachable.py
+++ b/ooni/nettests/experimental/peer_http_reachable.py
@@ -27,9 +27,9 @@ class PeerHttpReachable(httpt.HTTPTest):
         self.localOptions['withoutbody'] = 1
         log.msg(str(self.input.split()))
         url = self.input
-        if '/' not in url:  # for ``PUB_ADDR:PORT`` entries
+        if '/' not in url:  # fix ``PUB_ADDR:PORT`` entries
             url = url + '/'
-        if not url.beginswith('http://'):  # for ``PUB_ADDR:PORT[/?l=LOC_ADDR]`` entries
+        if not url.beginswith('http://'):  # fix ``PUB_ADDR:PORT[/?QUERY_ARGS]`` entries
             url = 'http://' + url
         self.http_url = url
         self.report['http_success'] = False

--- a/ooni/nettests/experimental/peer_http_reachable.py
+++ b/ooni/nettests/experimental/peer_http_reachable.py
@@ -26,8 +26,12 @@ class PeerHttpReachable(httpt.HTTPTest):
         """
         self.localOptions['withoutbody'] = 1
         log.msg(str(self.input.split()))
-        self.ip, self.port = self.input.split(":")
-        self.http_url = "http://" + self.ip+":"+self.port + '/'
+        url = self.input
+        if '/' not in url:  # for ``PUB_ADDR:PORT`` entries
+            url = url + '/'
+        if not url.beginswith('http://'):  # for ``PUB_ADDR:PORT[/?l=LOC_ADDR]`` entries
+            url = 'http://' + url
+        self.http_url = url
         self.report['http_success'] = False
 
     def test_http_speed(self):

--- a/ooni/nettests/experimental/peer_locator_test.py
+++ b/ooni/nettests/experimental/peer_locator_test.py
@@ -119,6 +119,8 @@ class PeerLocator(tcpt.TCPTest):
                 break
             if proc_ret == 2 and not random_port:  #the forced port was busy
                 raise RuntimeError("failed to bind to requested port %s" % http_server_port)
+            if proc_ret == 3:  #issues with UPnP port mapping
+                raise RuntimeError("failed to map port using UPnP")
             #retry with another port
         else:
             #fail, do not report a failed port or a port not used by us

--- a/ooni/nettests/experimental/peer_locator_test.py
+++ b/ooni/nettests/experimental/peer_locator_test.py
@@ -96,8 +96,7 @@ class PeerLocator(tcpt.TCPTest):
         if is_private_address(local_ip):
             behind_nat = True
         else:  #still check our visible address (if none, assume NAT)
-            public_ip = get_my_public_ip()
-            behind_nat = (public_ip != local_ip)
+            behind_nat = (get_my_public_ip() != local_ip)
 
         #first we spawn a http server
 

--- a/ooni/nettests/experimental/peer_locator_test.py
+++ b/ooni/nettests/experimental/peer_locator_test.py
@@ -110,7 +110,9 @@ class PeerLocator(tcpt.TCPTest):
                     http_server_port = str(random.randint(1025, 65535))
 
             log.msg("running an http server on port %s"%http_server_port)
-            proc = subprocess.Popen(['python', 'ooni/utils/simple_http.py', '--port', http_server_port])
+            proc = subprocess.Popen([
+                'python', 'ooni/utils/simple_http.py', '--port', http_server_port,
+                '--upnp' if behind_nat else '--noupnp'])
             time.sleep(1)  #wait for start or crash
             proc_ret = proc.poll()
             if proc_ret is None:  #the server is running (or less probably too slow to start)

--- a/ooni/nettests/experimental/peer_locator_test.py
+++ b/ooni/nettests/experimental/peer_locator_test.py
@@ -95,7 +95,7 @@ class PeerLocator(tcpt.TCPTest):
         local_ip = self.transport.getHost().host
         if is_private_address(local_ip):
             behind_nat = true
-        else:  # still check our visible address
+        else:  #still check our visible address (if none, assume NAT)
             public_ip = get_my_public_ip()
             behind_nat = (public_ip != local_ip)
 

--- a/ooni/nettests/experimental/peer_locator_test.py
+++ b/ooni/nettests/experimental/peer_locator_test.py
@@ -86,7 +86,9 @@ class PeerLocator(tcpt.TCPTest):
                                 
         self.address, self.port = self.localOptions['backend'].split(":")
         self.port = int(self.port)
-        payload =  http_server_port #http server port, we ultimately need STUN(T) to discover this
+        # Local IP address and HTTP server port,
+        # we ultimately need STUN(T) to discover their public counterparts.
+        payload = '%s:%s' % (self.transport.getHost().host, http_server_port)
         d = self.sendPayload(payload)
         d.addErrback(connection_failed)
         d.addCallback(got_response)

--- a/ooni/nettests/experimental/peer_locator_test.py
+++ b/ooni/nettests/experimental/peer_locator_test.py
@@ -128,9 +128,9 @@ class PeerLocator(tcpt.TCPTest):
                                 
         self.address, self.port = self.localOptions['backend'].split(":")
         self.port = int(self.port)
-        # Local IP address and HTTP server port,
-        # we ultimately need STUN(T) to discover their public counterparts.
-        payload = '%s:%s' % (local_ip, http_server_port)
+        # HTTP server port and flags.
+        payload = str(http_server_port)
+        payload += ' nat' if behind_nat else ' nonat'
         d = self.sendPayload(payload)
         d.addErrback(connection_failed)
         d.addCallback(got_response)

--- a/ooni/nettests/experimental/peer_locator_test.py
+++ b/ooni/nettests/experimental/peer_locator_test.py
@@ -94,7 +94,7 @@ class PeerLocator(tcpt.TCPTest):
         #identify whether we are behind NAT
         local_ip = self.transport.getHost().host
         if is_private_address(local_ip):
-            behind_nat = true
+            behind_nat = True
         else:  #still check our visible address (if none, assume NAT)
             public_ip = get_my_public_ip()
             behind_nat = (public_ip != local_ip)

--- a/ooni/nettests/experimental/peer_locator_test.py
+++ b/ooni/nettests/experimental/peer_locator_test.py
@@ -117,9 +117,9 @@ class PeerLocator(tcpt.TCPTest):
             proc_ret = proc.poll()
             if proc_ret is None:  #the server is running (or less probably too slow to start)
                 break
-            if proc_ret == 2 and not random_port:  #the forced port was busy
+            elif proc_ret == 2 and not random_port:  #the forced port was busy
                 raise RuntimeError("failed to bind to requested port %s" % http_server_port)
-            if proc_ret == 3:  #issues with UPnP port mapping
+            elif proc_ret == 3:  #issues with UPnP port mapping
                 raise RuntimeError("failed to map port using UPnP")
             #retry with another port
         else:

--- a/ooni/utils/simple_http.py
+++ b/ooni/utils/simple_http.py
@@ -24,34 +24,38 @@ class Hello(Resource):
         with open('var/big_file.dat', 'r') as big_file:
             return big_file.read()
 
-listen_port = DEFAULT_PORT
-use_upnp = False
+def main():
+    listen_port = DEFAULT_PORT
+    use_upnp = False
 
-for i in range(0, len(sys.argv)):
-    arg = sys.argv[i]
-    if arg == "--port":
-        listen_port = int(sys.argv[i+1])
-    elif arg == "--upnp":
-        use_upnp = True
-    elif arg == "--noupnp":
-        use_upnp = False
+    for i in range(0, len(sys.argv)):
+        arg = sys.argv[i]
+        if arg == "--port":
+            listen_port = int(sys.argv[i+1])
+        elif arg == "--upnp":
+            use_upnp = True
+        elif arg == "--noupnp":
+            use_upnp = False
 
-if use_upnp:
-    upnp = UPnP()
-    upnp.discoverdelay = 10
-    ndevs = upnp.discover()
-    if ndevs == 0:
-        error("No UPnP IGD devices were discovered", EXIT_UPNP_FAILED)
-    if not upnp.addportmapping(listen_port, 'TCP', upnp.lanaddr, listen_port,
-                               "OONI simple HTTP peer", ''):
-        error("Failed to create UPnP port mapping", EXIT_UPNP_FAILED)
+    if use_upnp:
+        upnp = UPnP()
+        upnp.discoverdelay = 10
+        ndevs = upnp.discover()
+        if ndevs == 0:
+            error("No UPnP IGD devices were discovered", EXIT_UPNP_FAILED)
+        if not upnp.addportmapping(listen_port, 'TCP', upnp.lanaddr, listen_port,
+                                   "OONI simple HTTP peer", ''):
+            error("Failed to create UPnP port mapping", EXIT_UPNP_FAILED)
 
-## XXXX configure auto-removal of mapping
+    ## XXXX configure auto-removal of mapping
 
-site = server.Site(Hello())
-try:
-    reactor.listenTCP(listen_port, site)
-    reactor.run()
-except CannotListenError:
-    error("Someone else is already listening on " + str(listen_port),
-          EXIT_BIND_FAILED)
+    site = server.Site(Hello())
+    try:
+        reactor.listenTCP(listen_port, site)
+        reactor.run()
+    except CannotListenError:
+        error("Someone else is already listening on " + str(listen_port),
+              EXIT_BIND_FAILED)
+
+if __name__ == '__main__':
+    main()

--- a/ooni/utils/simple_http.py
+++ b/ooni/utils/simple_http.py
@@ -1,3 +1,5 @@
+from miniupnpc import UPnP
+
 from twisted.internet import reactor
 from twisted.internet.error import CannotListenError
 from twisted.web import static, server
@@ -6,6 +8,12 @@ from twisted.web.resource import Resource
 import sys
 
 DEFAULT_PORT = 8000
+EXIT_BIND_FAILED = 2
+EXIT_UPNP_FAILED = 3
+
+def error(message, code):
+    sys.stderr.write(message)
+    sys.exit(code)
 
 class Hello(Resource):
 
@@ -17,15 +25,33 @@ class Hello(Resource):
             return big_file.read()
 
 listen_port = DEFAULT_PORT
+use_upnp = False
 
 for i in range(0, len(sys.argv)):
-    if  sys.argv[i] == "--port":
+    arg = sys.argv[i]
+    if arg == "--port":
         listen_port = int(sys.argv[i+1])
-            
+    elif arg == "--upnp":
+        use_upnp = True
+    elif arg == "--noupnp":
+        use_upnp = False
+
+if use_upnp:
+    upnp = UPnP()
+    upnp.discoverdelay = 10
+    ndevs = upnp.discover()
+    if ndevs == 0:
+        error("No UPnP IGD devices were discovered", EXIT_UPNP_FAILED)
+    if not upnp.addportmapping(listen_port, 'TCP', upnp.lanaddr, listen_port,
+                               "OONI simple HTTP peer", ''):
+        error("Failed to create UPnP port mapping", EXIT_UPNP_FAILED)
+
+## XXXX configure auto-removal of mapping
+
 site = server.Site(Hello())
 try:
     reactor.listenTCP(listen_port, site)
     reactor.run()
 except CannotListenError:
-    sys.stderr.write("Someone else is already listening on " + str(listen_port))
-    sys.exit(2)
+    error("Someone else is already listening on " + str(listen_port),
+          EXIT_BIND_FAILED)

--- a/ooni/utils/simple_http.py
+++ b/ooni/utils/simple_http.py
@@ -42,15 +42,15 @@ def main():
     if use_upnp:
         upnp = UPnP()
         upnp.discoverdelay = 10
-        ndevs = upnp.discover()
-        if ndevs == 0:
+        if upnp.discover() < 1:
             error("No UPnP IGD devices were discovered", EXIT_UPNP_FAILED)
         upnp.selectigd()
-        if not upnp.addportmapping(listen_port, 'TCP', upnp.lanaddr, listen_port,
-                                   "OONI simple HTTP peer", ''):
+        if not upnp.addportmapping(
+                listen_port, 'TCP', upnp.lanaddr, listen_port,
+                "OONI simple HTTP peer", ''):
             error("Failed to create UPnP port mapping", EXIT_UPNP_FAILED)
 
-    ## XXXX configure auto-removal of mapping
+        ## XXXX configure auto-removal of mapping
 
     # Run the HTTP server.
     site = server.Site(Hello())

--- a/ooni/utils/simple_http.py
+++ b/ooni/utils/simple_http.py
@@ -45,6 +45,7 @@ def main():
         ndevs = upnp.discover()
         if ndevs == 0:
             error("No UPnP IGD devices were discovered", EXIT_UPNP_FAILED)
+        upnp.selectigd()
         if not upnp.addportmapping(listen_port, 'TCP', upnp.lanaddr, listen_port,
                                    "OONI simple HTTP peer", ''):
             error("Failed to create UPnP port mapping", EXIT_UPNP_FAILED)

--- a/ooni/utils/simple_http.py
+++ b/ooni/utils/simple_http.py
@@ -28,6 +28,7 @@ def main():
     listen_port = DEFAULT_PORT
     use_upnp = False
 
+    # Parse command line options.
     for i in range(0, len(sys.argv)):
         arg = sys.argv[i]
         if arg == "--port":
@@ -37,6 +38,7 @@ def main():
         elif arg == "--noupnp":
             use_upnp = False
 
+    # Configure a UPnP port mapping if requested.
     if use_upnp:
         upnp = UPnP()
         upnp.discoverdelay = 10
@@ -49,6 +51,7 @@ def main():
 
     ## XXXX configure auto-removal of mapping
 
+    # Run the HTTP server.
     site = server.Site(Hello())
     try:
         reactor.listenTCP(listen_port, site)

--- a/ooni/utils/simple_http.py
+++ b/ooni/utils/simple_http.py
@@ -5,6 +5,7 @@ from twisted.internet.error import CannotListenError
 from twisted.web import static, server
 from twisted.web.resource import Resource
 
+import atexit
 import sys
 
 DEFAULT_PORT = 8000
@@ -49,8 +50,8 @@ def main():
                 listen_port, 'TCP', upnp.lanaddr, listen_port,
                 "OONI simple HTTP peer", ''):
             error("Failed to create UPnP port mapping", EXIT_UPNP_FAILED)
-
-        ## XXXX configure auto-removal of mapping
+        # Remove the configured port mapping on exit.
+        atexit.register(upnp.deleteportmapping, listen_port, 'TCP')
 
     # Run the HTTP server.
     site = server.Site(Hello())

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pydumbnet
 zope.interface
 certifi
 klein
+miniupnpc


### PR DESCRIPTION
This corresponds to <https://github.com/vmon/ooni-backend/pull/2>, i.e. the
test reports both the local IP address and port of the HTTP server.  It
retrieves a (possibly incomplete) URL from the helper via the input file; the
entry may have any of the following forms:

  - ``PUB_ADDR:PORT``, current version before that PR
  - ``PUB_ADDR:PORT/?l=LOC_ADDR``, entries added after PR in helper
  - ``http://PUB_ADDR:PORT/?l=LOC_ADDR`` or other HTTP URLs for future,
    backwards-incompatible PRs