### PR TITLE
Pass environment variables to P2P BitTorrent test script

### DIFF
--- a/ooni/nettests/experimental/p2p_bittorrent_test.py
+++ b/ooni/nettests/experimental/p2p_bittorrent_test.py
@@ -1,3 +1,5 @@
+import os
+
 from twisted.internet import defer
 
 from ooni.templates import process
@@ -10,4 +12,5 @@ class TestP2PBittorrentTest(process.ProcessTest):
 
     @defer.inlineCallbacks
     def test_bittorent(self):
-        yield self.run(["/opt/transmission/run-test.sh"])
+        # Invoke the test script with environment variables in place.
+        yield self.run(["/opt/transmission/run-test.sh"], env=os.environ)


### PR DESCRIPTION
Otherwise the script runs with no environment variables (or possibly just
``PWD``) and things like tilde expansion don't work.  This results in the
script not cleaning up Transmission files, which may cause that a torrent
whose files were previously completely downloaded is never tried again.